### PR TITLE
Update running instructions, slim down Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+**/.DS_Store
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/secrets.dev.yaml
+**/values.dev.yaml
+/bin
+/target
+LICENSE
+README.md

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+#!/bin/bash
+strict_env
+
+dotenv_if_exists .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,46 @@
-FROM rust:1.72.1 as build
+# syntax=docker/dockerfile:1
+FROM rust:1.72.1-slim-bullseye AS build
+ARG APP_NAME=aqi-alert-bot
+WORKDIR /app
 
-COPY src/ /build/src
-COPY Cargo.toml /build/Cargo.toml
-COPY Cargo.lock /build/Cargo.lock
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
-WORKDIR /build
-RUN cargo build --release
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-CMD ["/build/target/release/aqi-alert-bot"]
+# Required for openssl-sys
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get --no-install-recommends install -y pkg-config libssl-dev
+
+RUN --mount=type=bind,source=src,target=src \
+    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+    --mount=type=cache,target=/app/target/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    cargo build --locked --release && \
+    cp ./target/release/$APP_NAME /bin/server
+
+FROM debian:bullseye-slim AS final
+
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get --no-install-recommends install -y ca-certificates
+
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+USER appuser
+
+COPY --from=build /bin/server /bin/
+
+CMD ["/bin/server"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,71 @@
-aqi-alert-bot
+# aqi-alert-bot
 
-Environment Variables:
- * DISCORD_WEBHOOK_URL - required, webhook URL for the channel. Found in the channel settings
- * AQI_API_TOKEN - token acquired from https://aqicn.org/api/ to access their API
- * LAT_LONG - latitude and longitude to monitor AQI of in the format lat;long, e.g. 33.6772973;-106.477862, notice the semicolon as the delimiter, not a comma.
- * AQI_THRESHOLD - AQI threshold you want to monitor the crossing of, see https://www.airnow.gov/aqi/aqi-basics/ for more detials
- * MAX_ERRORS - max number of consecutive errors before the bot sends an error message to the designated discord chat, no tuning done here no idea what a good number is I'm useing 5
- * POLL_INTERVAL - number of seconds between API requests, minimum of 60 is likely best due to frequency of station updates
+Discord bot to alert when AQI passes a specified threshold.
+
+## Running
+
+1. Get a [token][aqi-token] to get air quality data, and add it to a `.env` file
+
+   ```shell
+   AQI_API_TOKEN=some-token
+   ```
+
+1. [Create a webhook][create-webhook] in your Discord server
+   1. Create a new channel, if needed
+   1. Server settings -> Integrations -> Create Webhook (or "View webhooks -> New
+     Webhook)
+   1. Expand the new webhook
+   1. Rename to "AQI bot" or similar, switch to correct channel, and save
+   1. Copy webhook URL and add to the `.env` file:
+
+      ```shell
+      DISCORD_WEBHOOK_URL="https://example.com"
+      ```
+
+1. [Get latitude and longitude][latlong], and add to `.env` in the format
+   `lat;long`, e.g. `33.6772973;-106.477862` (notice the semicolon as the
+   delimiter, not a comma)
+
+   ```shell
+   LAT_LONG="33.6772973;-106.477862"
+   ```
+
+1. Add additional configuration variables to `.env`:
+
+   * `AQI_THRESHOLD` - U.S. AQI threshold you want to monitor the crossing of,
+     see <https://www.airnow.gov/aqi/aqi-basics/> for more details
+   * `MAX_ERRORS` - max number of consecutive errors before the bot sends an
+     error message to the designated discord chat, no tuning done here no idea
+     what a good number is (I'm using 5)
+   * `POLL_INTERVAL` - number of seconds between API requests, minimum of 60 is
+     likely best due to frequency of station updates
+
+   There should now be a `.env` file that looks like this:
+
+   ```shell
+   AQI_API_TOKEN=some-token
+   DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/some-stuff"
+   LAT_LONG="33.6772973;-106.477862"
+   AQI_THRESHOLD=50
+   MAX_ERRORS=5
+   POLL_INTERVAL=600
+   ```
+
+1. Source the `.env` file
+
+   1. Option 1: install [`direnv`][direnv-install], install [shell
+      hooks][direnv-hooks], and run `direnv allow`. This will automatically load
+      the environment variables when inside the directory, and reload them if
+      they're changed.
+
+   1. Option 2: manually run a command like `set -a; source .env; set +a` (if
+      using a POSIX-compliant shell like `bash` or `zsh`)
+
+1. Run the bot: `cargo run`
+
+[aqi-token]: https://aqicn.org/data-platform/token/
+[create-webhook]: https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
+[latlong]: https://www.latlong.net/convert-address-to-lat-long.html
+[direnv-install]: https://direnv.net/docs/installation.html
+[direnv-hooks]: https://direnv.net/docs/hook.html
+[shuttle]: https://github.com/shuttle-hq/shuttle

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Discord bot to alert when AQI passes a specified threshold.
    1. Copy webhook URL and add to the `.env` file:
 
       ```shell
-      DISCORD_WEBHOOK_URL="https://example.com"
+      # no quotes
+      DISCORD_WEBHOOK_URL=https://example.com
       ```
 
 1. [Get latitude and longitude][latlong], and add to `.env` in the format
@@ -27,7 +28,8 @@ Discord bot to alert when AQI passes a specified threshold.
    delimiter, not a comma)
 
    ```shell
-   LAT_LONG="33.6772973;-106.477862"
+   # no quotes
+   LAT_LONG=33.6772973;-106.477862
    ```
 
 1. Add additional configuration variables to `.env`:
@@ -44,8 +46,8 @@ Discord bot to alert when AQI passes a specified threshold.
 
    ```shell
    AQI_API_TOKEN=some-token
-   DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/some-stuff"
-   LAT_LONG="33.6772973;-106.477862"
+   DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/some-stuff
+   LAT_LONG=33.6772973;-106.477862
    AQI_THRESHOLD=50
    MAX_ERRORS=5
    POLL_INTERVAL=600
@@ -58,8 +60,14 @@ Discord bot to alert when AQI passes a specified threshold.
       the environment variables when inside the directory, and reload them if
       they're changed.
 
-   1. Option 2: manually run a command like `set -a; source .env; set +a` (if
-      using a POSIX-compliant shell like `bash` or `zsh`)
+   1. Option 2: manually run a command like [this][thx-stackoverflow]: (if using
+      a POSIX-compliant shell like `bash` or `zsh`)
+
+      ```bash
+      while IFS== read -r key value; do
+        printf -v "$key" %s "$value" && export "$key"
+      done <.env
+      ```
 
 1. Run the bot: `cargo run`
 
@@ -68,4 +76,4 @@ Discord bot to alert when AQI passes a specified threshold.
 [latlong]: https://www.latlong.net/convert-address-to-lat-long.html
 [direnv-install]: https://direnv.net/docs/installation.html
 [direnv-hooks]: https://direnv.net/docs/hook.html
-[shuttle]: https://github.com/shuttle-hq/shuttle
+[thx-stackoverflow]: https://stackoverflow.com/questions/43267413/how-to-set-environment-variables-from-env-file

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn main() {
             webhook
                 .execute(&http, false, |w| {
                     w.content(format!(
-                        "@everyone AQI is now above {aqi_threshold}\nCurrent AQI = {aqi}"
+                        "AQI is now above {aqi_threshold}\nCurrent AQI = {aqi}"
                     ))
                 })
                 .await
@@ -64,7 +64,7 @@ async fn main() {
             webhook
                 .execute(&http, false, |w| {
                     w.content(format!(
-                        "@everyone AQI is now below {aqi_threshold}\nCurrent AQI = {aqi}"
+                        "AQI is now below {aqi_threshold}\nCurrent AQI = {aqi}"
                     ))
                 })
                 .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,20 @@
 use std::env;
 
+use serde_json::Value;
 use serenity::http::Http;
 use serenity::model::webhook::Webhook;
-use serde_json::Value;
 use tokio::time::{sleep, Duration};
 
 #[tokio::main]
 async fn main() {
     // Set necessary env vars
-    let aqi_api_token = env::var("AQI_API_TOKEN")
-        .expect("Expected an AQI_API_TOKEN in the environment");
+    let aqi_api_token =
+        env::var("AQI_API_TOKEN").expect("Expected an AQI_API_TOKEN in the environment");
 
-    let lat_long = env::var("LAT_LONG")
-        .expect("Expected a LAT_LONG in the environment");
+    let lat_long = env::var("LAT_LONG").expect("Expected a LAT_LONG in the environment");
 
-    let discord_webhook = env::var("DISCORD_WEBHOOK_URL")
-        .expect("Expected a DISCORD_WEBHOOK_URL in the environment");
+    let discord_webhook =
+        env::var("DISCORD_WEBHOOK_URL").expect("Expected a DISCORD_WEBHOOK_URL in the environment");
 
     let aqi_threshold = env::var("AQI_THRESHOLD")
         .expect("Expected an AQI_THRESHOLD in the environment")
@@ -35,39 +34,39 @@ async fn main() {
 
     // Store formatted url for AQI API calls
     let aqi_url = format!("https://api.waqi.info/feed/geo:{lat_long}/?token={aqi_api_token}");
-    
+
     // Configure webhook endpoint from above env var
-    let webhook = Webhook::from_url(&http, &discord_webhook).await.expect("Error creating webhook object from url.");
+    let webhook = Webhook::from_url(&http, &discord_webhook)
+        .await
+        .expect("Error creating webhook object from url.");
 
     loop {
         // Get json resp from aqi tracker site
-        let body = reqwest::get(&aqi_url)
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        
+        let body = reqwest::get(&aqi_url).await.unwrap().text().await.unwrap();
+
         // Get current AQI from response JSON payload
         let aqi_json: Value = serde_json::from_str(&body).expect("Could not deserialize json.");
-        let aqi = aqi_json["data"]["aqi"]
-            .to_string()
-            .parse::<u64>()
-            .expect("Expected value that can be parsed to u64 at .data.aqi from AQI API JSON body.");
-        
+        let aqi = aqi_json["data"]["aqi"].to_string().parse::<u64>().expect(
+            "Expected value that can be parsed to u64 at .data.aqi from AQI API JSON body.",
+        );
+
         // Send message via webhook if necessary
         if aqi > aqi_threshold && hist_aqi < aqi_threshold {
-            webhook.execute(&http, 
-                false, 
-                |w| 
-                w.content(format!("@everyone AQI is now above {aqi_threshold}\nCurrent AQI = {aqi}")))
+            webhook
+                .execute(&http, false, |w| {
+                    w.content(format!(
+                        "@everyone AQI is now above {aqi_threshold}\nCurrent AQI = {aqi}"
+                    ))
+                })
                 .await
                 .expect("Error executing webhook");
         } else if aqi < aqi_threshold && hist_aqi > aqi_threshold {
-            webhook.execute(&http, 
-                false, 
-                |w| 
-                w.content(format!("@everyone AQI is now below {aqi_threshold}\nCurrent AQI = {aqi}")))
+            webhook
+                .execute(&http, false, |w| {
+                    w.content(format!(
+                        "@everyone AQI is now below {aqi_threshold}\nCurrent AQI = {aqi}"
+                    ))
+                })
                 .await
                 .expect("Error executing webhook");
         } else {


### PR DESCRIPTION
The commits can be read individually. This PR:

- Fleshes out the README a little
- Runs `rustfmt` on the rust code
- Adds `direnv` for `.env` loading (let me know if you want me to drop this and remove it from the README, or use nix or something else)
- Removes the @everyone ping (reasoning in commit message)
- Makes the docker build faster, and gets the image size from 2.5gb -> 95mb

I did not get around to writing how to run this with docker because I do not want to learn docker compose today, and `docker-compose up` was behaving in strange enough ways that I cannot just say "do that." I could add a `docker run --env-file .env` command to the README if you want, though.